### PR TITLE
refactor: SpEL 파싱 로직 분리 및 단순화

### DIFF
--- a/src/main/java/io/github/daegwon/ticketing_system/aop/DistributedLockAop.java
+++ b/src/main/java/io/github/daegwon/ticketing_system/aop/DistributedLockAop.java
@@ -1,19 +1,15 @@
 package io.github.daegwon.ticketing_system.aop;
 
 import io.github.daegwon.ticketing_system.annotation.DistributedLock;
+import io.github.daegwon.ticketing_system.parser.SpELParser;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.reflect.MethodSignature;
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
-import org.springframework.expression.EvaluationContext;
-import org.springframework.expression.Expression;
-import org.springframework.expression.ExpressionParser;
-import org.springframework.expression.common.TemplateParserContext;
-import org.springframework.expression.spel.standard.SpelExpressionParser;
-import org.springframework.expression.spel.support.StandardEvaluationContext;
 import org.springframework.stereotype.Component;
 
 import java.util.concurrent.TimeUnit;
@@ -21,6 +17,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * 분산 락을 위한 AOP 클래스
  */
+@Slf4j
 @Aspect
 @Component
 @RequiredArgsConstructor
@@ -28,6 +25,7 @@ public class DistributedLockAop {
 
     private final RedissonClient redissonClient;
     private final AopForTransaction aopForTransaction;
+    private final SpELParser spELParser;
 
     /**
      * 분산 락으로 메서드를 감싸는 Around 어드바이스
@@ -39,8 +37,10 @@ public class DistributedLockAop {
     @Around("@annotation(distributedLock)")
     public Object lock(ProceedingJoinPoint joinPoint, DistributedLock distributedLock) throws Throwable {
         MethodSignature signature = (MethodSignature) joinPoint.getSignature();
-        String key = createDynamicKey(signature.getParameterNames(), joinPoint.getArgs(), distributedLock.key());
+        String key = spELParser.createDynamicKey(signature.getParameterNames(), joinPoint.getArgs(), distributedLock.key());
         RLock lock = redissonClient.getLock(key);
+
+        log.info("Lock acquired for {}", key);
 
         try {
             if (!lock.tryLock(10, 1, TimeUnit.SECONDS)) {
@@ -55,38 +55,6 @@ public class DistributedLockAop {
             if (lock.isLocked() && lock.isHeldByCurrentThread()) {
                 lock.unlock();
             }
-        }
-    }
-
-    /**
-     * SpEL을 사용해 동적인 락 키 생성
-     *
-     * @param parameterNames 메서드 파라미터 이름
-     * @param args 실제 전달된 인수 값
-     * @param keyExpression 동적 키 표현식
-     * @return 락 키
-     */
-    private String createDynamicKey(String[] parameterNames, Object[] args, String keyExpression) {
-        // SpEL 표현식이 없으면 정적 키로 판단하고 그대로 반환
-        if (!keyExpression.contains("#{")) {
-            return keyExpression;
-        }
-
-        // SpEL 파서와 컨텍스트 생성
-        ExpressionParser parser = new SpelExpressionParser();
-        EvaluationContext context = new StandardEvaluationContext();
-
-        // 메서드 파라미터를 SpEL 컨텍스트에 등록
-        for (int i = 0; i < parameterNames.length; i++) {
-            context.setVariable(parameterNames[i], args[i]);
-        }
-
-        try {
-            // SpEL 표현식 파싱 및 평가
-            Expression expression = parser.parseExpression(keyExpression, new TemplateParserContext());
-            return expression.getValue(context, String.class);
-        } catch (Exception e) {
-            throw new IllegalArgumentException("Failed to parse lock key expression: " + keyExpression, e);
         }
     }
 }

--- a/src/main/java/io/github/daegwon/ticketing_system/parser/SpELParser.java
+++ b/src/main/java/io/github/daegwon/ticketing_system/parser/SpELParser.java
@@ -1,0 +1,34 @@
+package io.github.daegwon.ticketing_system.parser;
+
+import org.springframework.expression.EvaluationContext;
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SpELParser {
+
+    /**
+     * SpEL을 사용해 동적인 락 키 생성
+     *
+     * @param parameterNames 메서드 파라미터 이름
+     * @param args 실제 전달된 인수 값
+     * @param keyExpression 동적 키 표현식
+     * @return 생선된 키 이름
+     */
+    public String createDynamicKey(String[] parameterNames, Object[] args, String keyExpression) {
+        // SpEL 파서와 컨텍스트 생성
+        ExpressionParser parser = new SpelExpressionParser();
+        EvaluationContext context = new StandardEvaluationContext();
+
+        // 메서드 파라미터를 SpEL 컨텍스트에 등록
+        for (int i = 0; i < parameterNames.length; i++) {
+            context.setVariable(parameterNames[i], args[i]);
+        }
+
+        // SpEL 표현식 파싱
+        return parser.parseExpression(keyExpression)
+                .getValue(context, String.class);
+    }
+}


### PR DESCRIPTION
#### 🪾 작업 브랜치
- feature/v5

#### 🚀 작업 내용
- SpEL 파싱 로직을 AOP 클래스와 분리(`SpELParser.class` 추가)
- SpEL 파싱 로직 단순화(필요 없는 로직 제거)
